### PR TITLE
check attribute perfect-scrollbar

### DIFF
--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -16,6 +16,7 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
       template: '<div><div ng-transclude></div></div>',
       replace: true,
       link: function($scope, $elem, $attr) {
+        if ($attr.perfectScrollbar == "false" || !$attr.perfectScrollbar) return;
         var el = $elem[0];
         var jqWindow = angular.element($window);
         var options = {};

--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -16,7 +16,7 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
       template: '<div><div ng-transclude></div></div>',
       replace: true,
       link: function($scope, $elem, $attr) {
-        if ($attr.perfectScrollbar == "false" || !$attr.perfectScrollbar) return;
+        if ($attr.perfectScrollbar == "false") return;
         var el = $elem[0];
         var jqWindow = angular.element($window);
         var options = {};


### PR DESCRIPTION
if the attribute perfect-scrollbar is set to false, the directive won't be applied. like this, you can change the behaviour conditionally. for example, you can switch the scrollbars off on touch devices:
`<div ng-attr-perfect-scrollbar="{{boolean_is_true ? 'true' : 'false'}}>`
